### PR TITLE
docs/add-code-of-conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Our Values
+
+We strive to act in ways that center our shared values:
+
+- **Empathy and Kindness** - Treating others with compassion and understanding
+- **Respect** - Honoring different opinions, viewpoints, and experiences
+- **Constructive Feedback** - Giving and receiving feedback gracefully
+- **Accountability** - Taking responsibility for our mistakes and learning from them
+- **Community Focus** - Prioritizing what's best for the overall community
+- **Inclusivity** - Welcoming and supporting all contributors
+
+## Unacceptable Behavior
+
+We do not tolerate:
+
+- Harassment, intimidation, or discrimination of any kind
+- Trolling, insults, derogatory comments, or personal attacks
+- Sexual language, imagery, or unwelcome advances
+- Publishing others' private information without permission
+- Threats of violence or encouraging self-harm
+- Sustained disruption of community activities
+- Other conduct inappropriate in a professional setting
+
+## Enforcement 
+
+### Reporting 
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+Report violations to project maintainers at **oscf.community@gmail.com**. 
+
+### Response
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+### Consequences
+
+Depending on severity, consequences may include:
+
+1. **Correction** - Private warning with explanation
+2. **Warning** - Formal warning with no-contact period
+3. **Temporary Ban** - Time-limited ban from community spaces
+4. **Permanent Ban** - Permanent removal from the community
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+Adapted from [Contributor Covenant](https://www.contributor-covenant.org/) v3.0, licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
Establishes expected behavior, reporting process, and enforcement steps for all contributors.